### PR TITLE
Add license to gemspec

### DIFF
--- a/rack-mount.gemspec
+++ b/rack-mount.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.description = <<-EOS
     A stackable dynamic tree based Rack router.
   EOS
+  s.license     = "MIT"
 
   s.files = Dir["README.rdoc", "LICENSE", "lib/**/*.rb"]
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.